### PR TITLE
Update draft to match Privacy Pass Issuance Protocol draft 16

### DIFF
--- a/draft-ietf-privacypass-rate-limit-tokens.md
+++ b/draft-ietf-privacypass-rate-limit-tokens.md
@@ -448,7 +448,7 @@ object whose field names and values are raw values and URLs for the parameters.
 | Field Name           | Value                                            |
 |:---------------------|:-------------------------------------------------|
 | issuer-policy-window | Issuer Policy Window as a JSON number            |
-| issuer-request-uri   | Issuer Request URI resource URL as a JSON string |
+| issuer-request-uri   | Issuer Request URI resource URL as a JSON string, as defined in {{ISSUANCE}} |
 | encap-keys           | List of Encapsulation Key values, each as a base64url encoded EncapsulationKey value |
 | token-keys           | List of Token Key values, each represented as JSON objects |
 
@@ -487,8 +487,10 @@ Issuers MUST support at least one Token Key per origin. Issuers MAY support
 multiple Token Key values for the same Origin in order to support rotation.
 
 As in {{ISSUANCE}}, Issuer directory resources have the media type
-"application/json" and are located at the well-known location
-"/.well-known/token-issuer-directory".
+"application/private-token-issuer-directory" and are located at the well-known location
+"/.well-known/private-token-issuer-directory".
+
+Issuers SHOULD use HTTP cache directives to permit caching of this resource {{!RFC5861}}, as defined in the issuance {{ISSUANCE}} protocol.
 
 # Token Challenge Requirements
 
@@ -781,7 +783,7 @@ value, calculated as described in {{encrypt-origin}}.
 
 The Client then generates an HTTP POST request to send through the Attester to
 the Issuer, with the TokenRequest as the body. The media type for this request
-is "message/token-request". The Client includes the "Sec-Token-Origin-Alias" header,
+is "application/private-token-request". The Client includes the "Sec-Token-Origin-Alias" header,
 whose value is Client's Origin Alias; the "Sec-Token-Client" header, whose value is
 Client Key; and the "Sec-Token-Request-Blind" header, whose value is request_blind.
 The Client sends this request to the Attester's proxy URI. An example request is
@@ -793,9 +795,9 @@ shown below, where the Issuer Name is "issuer.net" and the Attester URI template
 :scheme = https
 :authority = attester.net
 :path = /token-request?issuer=issuer.net
-accept = message/token-response
+accept = application/private-token-response
 cache-control = no-cache, no-store
-content-type = message/token-request
+content-type = application/private-token-request
 content-length = <Length of TokenRequest>
 sec-token-origin-alias = Client's Origin Alias
 sec-token-client = Client Key
@@ -863,9 +865,9 @@ or region to which a Client belongs. An example request is shown below.
 :scheme = https
 :authority = issuer.net
 :path = /token-request
-accept = message/token-response
+accept = application/private-token-response
 cache-control = no-cache, no-store
-content-type = message/token-request
+content-type = application/private-token-request
 content-length = <Length of TokenRequest>
 
 <Bytes containing the TokenRequest>
@@ -916,7 +918,7 @@ The Issuer then encrypts `blind_sig` to the Client as described in {{encap-issue
 yielding `encrypted_token_response`.
 
 The Issuer generates an HTTP response with status code 200 whose body consists of
-blind_sig, with the content type set as "message/token-response", the
+blind_sig, with the content type set as "application/private-token-response", the
 index_key set in the "Sec-Token-Origin-Alias" header, and the limit of tokens
 allowed for a Client for the Origin within a policy window set in the
 "Sec-Token-Limit" header. This limit SHOULD NOT be unique to a specific
@@ -925,7 +927,7 @@ the Client is accessing (see {{privacy-considerations}}).
 
 ~~~
 :status = 200
-content-type = message/token-response
+content-type = application/private-token-response
 content-length = <Length of blind_sig>
 sec-token-origin-alias = index_key
 sec-token-limit = Token limit


### PR DESCRIPTION
This draft has diverged from the main Privacy Pass Issuance Protocol draft, specifically around IANA registered content type and endpoints. This commit updates the rate limited draft to be more consistent. In addition, it mentions caching for the issuer directory, refering to its definition in the issuance draft.